### PR TITLE
Fixing lib path issue on several scripts

### DIFF
--- a/src/scripts/Remove-MSEdge.ps1
+++ b/src/scripts/Remove-MSEdge.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"Show-MessageDialog.psm1"
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\ui\"Show-MessageDialog.psm1"
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"Title-Templates.psm1"
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\debloat-helper\"Remove-ItemVerified.psm1"
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\debloat-helper\"Remove-UWPApp.psm1"

--- a/src/scripts/Remove-Xbox.ps1
+++ b/src/scripts/Remove-Xbox.ps1
@@ -1,5 +1,5 @@
-Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"Set-ServiceStartup.psm1"
-Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"Show-MessageDialog.psm1"
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\debloat-helper\"Set-ServiceStartup.psm1"
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\ui\"Show-MessageDialog.psm1"
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"Title-Templates.psm1"
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\debloat-helper\"Remove-UWPApp.psm1"
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\debloat-helper\"Set-ItemPropertyVerified.psm1"


### PR DESCRIPTION
This PR fixes the issue some scripts can't be used due to recent changes that moves some of the lib to the "appropriate" folder.