### PR TITLE
Update Remove-Xbox with new gaming app

### DIFF
--- a/src/scripts/Remove-Xbox.ps1
+++ b/src/scripts/Remove-Xbox.ps1
@@ -19,6 +19,7 @@ function Remove-Xbox() {
     $XboxApps = @(
         "Microsoft.GamingServices"          # Gaming Services
         "Microsoft.XboxApp"                 # Xbox Console Companion (Replaced by new App)
+        "Microsoft.GamingApp"
         "Microsoft.XboxGameCallableUI"
         "Microsoft.XboxGameOverlay"
         "Microsoft.XboxSpeechToTextOverlay"


### PR DESCRIPTION
On a fresh Windows 11 installation, the `Remove-Xbox` script still leaves an XBox app present - I've added its package name to the list of UWP apps to remove.