### PR TITLE
Update Use-DebloatSoftware.ps1

### DIFF
--- a/src/scripts/Use-DebloatSoftware.ps1
+++ b/src/scripts/Use-DebloatSoftware.ps1
@@ -13,9 +13,9 @@ function Use-DebloatSoftware() {
 
     If (!$Revert) {
         $AdwCleanerDl = "https://downloads.malwarebytes.com/file/adwcleaner"
-        $AdwCleanerOutput = (Request-FileDownload -FileURI $AdwCleanerDl -OutputFile "adwcleaner.exe")[-1]
+        [String] $AdwCleanerOutput = (Request-FileDownload -FileURI $AdwCleanerDl -OutputFile "adwcleaner.exe")
         Write-Status -Types "+" -Status "Running MalwareBytes AdwCleaner scanner..."
-        Start-Process -FilePath "$AdwCleanerOutput" -ArgumentList '/eula', '/clean', '/noreboot' -Wait
+        Start-Process -FilePath "$AdwCleanerOutput" -ArgumentList "/eula", "/clean", "/noreboot" -Wait
         Remove-ItemVerified $AdwCleanerOutput -Force
     }
 


### PR DESCRIPTION
Corrects the returned path of downloaded adwcleaner tool. 

Win10                          22H2
PSVersion                     5.1.19041.3693
PSEdition                      Desktop
PSCompatibleVersions  {1.0, 2.0, 3.0, 4.0...}
BuildVersion                 10.0.19041.3693
CLRVersion                   4.0.30319.42000
WSManStackVersion     3.0
PSRemotingProtocolVersion      2.3
SerializationVersion        1.1.0.1