### PR TITLE
Update Request-FileDownload.psm1

### DIFF
--- a/src/lib/Request-FileDownload.psm1
+++ b/src/lib/Request-FileDownload.psm1
@@ -30,7 +30,7 @@ function Request-FileDownload {
 
     If (!(Test-Path $OutputFolder)) {
         Write-Status -Types "@" -Status "$OutputFolder doesn't exist, creating folder..."
-        New-Item -Path $OutputFolder -ItemType Directory -Force
+        $OutputFolder = New-Item -Path $OutputFolder -ItemType Directory -Force
     }
 
     $FileLocation = Join-Path -Path $OutputFolder -ChildPath $OutputFile


### PR DESCRIPTION
Had to dig deeper... 
If the path "$(Get-TempScriptFolder)\downloads" is not existent and has to be created, the script will fail.  Cause of the error was a non-captured output in this function at corrected line.