### PR TITLE
Change resolution check to use the primary monitor's working area.

### DIFF
--- a/src/lib/ui/Get-CurrentResolution.psm1
+++ b/src/lib/ui/Get-CurrentResolution.psm1
@@ -5,45 +5,17 @@ function Get-CurrentResolution() {
     [OutputType([System.Object[]])]
     param ()
 
-    # Adapted from: https://www.reddit.com/r/PowerShell/comments/67no9x/comment/dgrry3b/?utm_source=share&utm_medium=web2x&context=3
-    $NumberOfScreens = (Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorBasicDisplayParams | Where-Object { $_.Active -like "True" }).Active.Count
-    $ScreenWidth = $null
-    $ScreenHeight = $null
+    Add-Type -AssemblyName System.Windows.Forms
 
-    Write-Verbose "Num. of Monitors: $NumberOfScreens"
+    # Get the primary screen's working area, which takes DPI scaling into account
+    $primaryScreen = [System.Windows.Forms.Screen]::PrimaryScreen
+    $bounds = $primaryScreen.Bounds
+    $workingArea = $primaryScreen.WorkingArea
 
-    If ($NumberOfScreens -eq 1) {
-        # Accepts Scaling/DPI
-        [System.Windows.Forms.SystemInformation]::VirtualScreen | ForEach-Object {
-            Write-Verbose "W: $($_.Width) | H: $($_.Height)"
+    $ScreenWidth = $workingArea.Width
+    $ScreenHeight = $workingArea.Height
 
-            If (!$ScreenWidth -or !$ScreenHeight) {
-                $ScreenWidth = $_.Width
-                $ScreenHeight = $_.Height
-            }
+    Write-Verbose "Primary Monitor: Width: $ScreenWidth, Height: $ScreenHeight (DPI Scaled)"
 
-            If (($_.Width) -and ($_.Width -le $ScreenWidth)) {
-                $ScreenWidth = $_.Width
-                $ScreenHeight = $_.Height
-            }
-        }
-    } Else {
-        # Doesn't accepts Scaling/DPI (rollback method)
-        Get-CimInstance -Class "Win32_VideoController" | ForEach-Object {
-            Write-Verbose "W: $($_.CurrentHorizontalResolution) | H: $($_.CurrentVerticalResolution)"
-
-            If (!$ScreenWidth -or !$ScreenHeight) {
-                $ScreenWidth = $_.CurrentHorizontalResolution
-                $ScreenHeight = $_.CurrentVerticalResolution
-            }
-
-            If (($_.CurrentHorizontalResolution) -and ($_.CurrentHorizontalResolution -le $ScreenWidth)) {
-                $ScreenWidth = $_.CurrentHorizontalResolution
-                $ScreenHeight = $_.CurrentVerticalResolution
-            }
-        }
-    }
-
-    Write-Verbose "Width: $ScreenWidth, Height: $ScreenHeight"
     return $ScreenWidth, $ScreenHeight
 }


### PR DESCRIPTION
Fixes oversized windows on multiple monitor setups when using dpi scaling.