### PR TITLE
misc: Use UTF-8 with BOM encoding for all .ps1/psm1 files

### DIFF
--- a/src/lib/Get-HardwareInfo.psm1
+++ b/src/lib/Get-HardwareInfo.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
 
 function Get-CPU() {
     [CmdletBinding()]

--- a/src/lib/Get-TempScriptFolder.psm1
+++ b/src/lib/Get-TempScriptFolder.psm1
@@ -1,3 +1,3 @@
-function Get-TempScriptFolder() {
+﻿function Get-TempScriptFolder() {
     return "$env:TEMP\Win-Debloat-Tools" # Using this function instead of using a Global variable to not trigger PSScriptAnalyzer
 }

--- a/src/lib/Install-Font.psm1
+++ b/src/lib/Install-Font.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Get-TempScriptFolder.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Get-TempScriptFolder.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
 
 # Adapted From: https://gist.github.com/anthonyeden/0088b07de8951403a643a8485af2709b?permalink_comment_id=3651336#gistcomment-3651336

--- a/src/lib/New-Shortcut.psm1
+++ b/src/lib/New-Shortcut.psm1
@@ -1,4 +1,4 @@
-# Adapted From: https://shellgeek.com/create-shortcuts-on-user-desktop-using-powershell/
+﻿# Adapted From: https://shellgeek.com/create-shortcuts-on-user-desktop-using-powershell/
 # Short circuit code: https://stackoverflow.com/a/26768902
 Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
 

--- a/src/lib/Open-File.psm1
+++ b/src/lib/Open-File.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\ui\Show-MessageDialog.psm1"
 
 function Open-PowerShellFilesCollection {

--- a/src/lib/Request-FileDownload.psm1
+++ b/src/lib/Request-FileDownload.psm1
@@ -1,4 +1,4 @@
-Import-Module BitsTransfer
+﻿Import-Module BitsTransfer
 Import-Module -DisableNameChecking "$PSScriptRoot\Get-TempScriptFolder.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
 

--- a/src/lib/Set-ConsoleStyle.psm1
+++ b/src/lib/Set-ConsoleStyle.psm1
@@ -1,4 +1,4 @@
-function Set-ConsoleStyle() {
+﻿function Set-ConsoleStyle() {
     [CmdletBinding()] param (
         [Parameter(Position = 0)]
         [ValidateSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 'A', 'B', 'C', 'D', 'E', 'F')]

--- a/src/lib/Set-RevertStatus.psm1
+++ b/src/lib/Set-RevertStatus.psm1
@@ -1,4 +1,4 @@
-function Set-RevertStatus() {
+﻿function Set-RevertStatus() {
     [CmdletBinding()]
     param (
         [Parameter(Position = 0, Mandatory)]

--- a/src/lib/Start-Logging.psm1
+++ b/src/lib/Start-Logging.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Get-TempScriptFolder.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Get-TempScriptFolder.psm1"
 
 function Start-Logging() {
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/lib/Unregister-DuplicatedPowerPlan.psm1
+++ b/src/lib/Unregister-DuplicatedPowerPlan.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Title-Templates.psm1"
 
 function Unregister-DuplicatedPowerPlan() {
     Begin {

--- a/src/lib/debloat-helper/Remove-ItemPropertyVerified.psm1
+++ b/src/lib/debloat-helper/Remove-ItemPropertyVerified.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Remove-ItemPropertyVerified() {
     param (

--- a/src/lib/debloat-helper/Remove-ItemVerified.psm1
+++ b/src/lib/debloat-helper/Remove-ItemVerified.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Remove-ItemVerified() {
     param (

--- a/src/lib/debloat-helper/Remove-UWPApp.psm1
+++ b/src/lib/debloat-helper/Remove-UWPApp.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Remove-UWPApp() {
     [CmdletBinding()]

--- a/src/lib/debloat-helper/Set-CapabilityState.psm1
+++ b/src/lib/debloat-helper/Set-CapabilityState.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Set-CapabilityState() {
     [CmdletBinding()]

--- a/src/lib/debloat-helper/Set-ItemPropertyVerified.psm1
+++ b/src/lib/debloat-helper/Set-ItemPropertyVerified.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Set-ItemPropertyVerified() {
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/lib/debloat-helper/Set-OptionalFeatureState.psm1
+++ b/src/lib/debloat-helper/Set-OptionalFeatureState.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Set-OptionalFeatureState() {
     [CmdletBinding()]

--- a/src/lib/debloat-helper/Set-ScheduledTaskState.psm1
+++ b/src/lib/debloat-helper/Set-ScheduledTaskState.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Set-ScheduledTaskState() {
     [CmdletBinding()]

--- a/src/lib/debloat-helper/Set-ServiceStartup.psm1
+++ b/src/lib/debloat-helper/Set-ServiceStartup.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function Set-ServiceStartup() {
     [CmdletBinding()]

--- a/src/lib/package-managers/Install-PackageManager.psm1
+++ b/src/lib/package-managers/Install-PackageManager.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 # Adapted from: https://github.com/ChrisTitusTech/win10script/blob/master/win10debloat.ps1
 # Adapted from: https://github.com/W4RH4WK/Debloat-Windows-10/blob/master/utils/install-basic-software.ps1

--- a/src/lib/package-managers/Manage-Chocolatey.psm1
+++ b/src/lib/package-managers/Manage-Chocolatey.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Install-PackageManager.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Install-PackageManager.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\Manage-DailyUpgradeJob.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\ui\Show-MessageDialog.psm1"

--- a/src/lib/package-managers/Manage-DailyUpgradeJob.psm1
+++ b/src/lib/package-managers/Manage-DailyUpgradeJob.psm1
@@ -1,4 +1,4 @@
-Import-Module PSScheduledJob
+﻿Import-Module PSScheduledJob
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 # Adapted from: https://blogs.technet.microsoft.com/heyscriptingguy/2013/11/23/using-scheduled-tasks-and-scheduled-jobs-in-powershell/

--- a/src/lib/package-managers/Manage-Software.psm1
+++ b/src/lib/package-managers/Manage-Software.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Manage-Chocolatey.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Manage-Chocolatey.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\Manage-Winget.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Open-File.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"

--- a/src/lib/package-managers/Manage-Winget.psm1
+++ b/src/lib/package-managers/Manage-Winget.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Install-PackageManager.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Install-PackageManager.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\Manage-DailyUpgradeJob.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Get-TempScriptFolder.psm1"

--- a/src/lib/package-managers/Update-AllPackage.psm1
+++ b/src/lib/package-managers/Update-AllPackage.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\ui\Show-MessageDialog.psm1"
 
 $Script:DoneTitle = "Information"

--- a/src/lib/ui/Get-CurrentResolution.psm1
+++ b/src/lib/ui/Get-CurrentResolution.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Ui-Helper.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Ui-Helper.psm1"
 
 function Get-CurrentResolution() {
     [CmdletBinding()]

--- a/src/lib/ui/Get-DefaultColor.psm1
+++ b/src/lib/ui/Get-DefaultColor.psm1
@@ -1,4 +1,4 @@
-function Get-DefaultColor() {
+﻿function Get-DefaultColor() {
     $Colors = @{
         Cyan          = "#25F7D8"
         DarkGray      = "#2C2C2C"

--- a/src/lib/ui/New-LayoutPage.psm1
+++ b/src/lib/ui/New-LayoutPage.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Ui-Helper.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Ui-Helper.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 function New-LayoutPage() {

--- a/src/lib/ui/Select-Folder.psm1
+++ b/src/lib/ui/Select-Folder.psm1
@@ -1,4 +1,4 @@
-# Adapted from: https://stackoverflow.com/questions/25690038/how-do-i-properly-use-the-folderbrowserdialog-in-powershell
+﻿# Adapted from: https://stackoverflow.com/questions/25690038/how-do-i-properly-use-the-folderbrowserdialog-in-powershell
 
 function Select-Folder() {
     [CmdletBinding()]

--- a/src/lib/ui/Show-MessageDialog.psm1
+++ b/src/lib/ui/Show-MessageDialog.psm1
@@ -1,4 +1,4 @@
-# Reference: https://michlstechblog.info/blog/powershell-show-a-messagebox/#:~:text=Sometimes%20while%20a%20powershell%20script,NET%20Windows.
+﻿# Reference: https://michlstechblog.info/blog/powershell-show-a-messagebox/#:~:text=Sometimes%20while%20a%20powershell%20script,NET%20Windows.
 function Use-WindowsForm() {
     [System.Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms") | Out-Null # Load assembly
 }

--- a/src/lib/ui/Ui-Helper.psm1
+++ b/src/lib/ui/Ui-Helper.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\Get-DefaultColor.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\Get-DefaultColor.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\Title-Templates.psm1"
 
 # Adapted from: https://stackoverflow.com/a/35965782

--- a/src/scripts/Backup-System.ps1
+++ b/src/scripts/Backup-System.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 
 $Script:TweakType = "Backup"

--- a/src/scripts/Install-DefaultAppsList.ps1
+++ b/src/scripts/Install-DefaultAppsList.ps1
@@ -1,4 +1,4 @@
-function Install-DefaultAppsList() {
+﻿function Install-DefaultAppsList() {
     # The following code is from Microsoft (Adapted): https://go.microsoft.com/fwlink/?LinkId=619547
     # Get all the provisioned packages
     $Packages = (Get-Item 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Applications') | Get-ChildItem

--- a/src/scripts/Invoke-DebloatSoftware.ps1
+++ b/src/scripts/Invoke-DebloatSoftware.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-TempScriptFolder.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-TempScriptFolder.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Request-FileDownload.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"

--- a/src/scripts/Optimize-Performance.ps1
+++ b/src/scripts/Optimize-Performance.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Open-File.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Open-File.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Unregister-DuplicatedPowerPlan.psm1"

--- a/src/scripts/Optimize-Privacy.ps1
+++ b/src/scripts/Optimize-Privacy.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemPropertyVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"

--- a/src/scripts/Optimize-Security.ps1
+++ b/src/scripts/Optimize-Security.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\utils\Individual-Tweaks.psm1"

--- a/src/scripts/Optimize-TaskScheduler.ps1
+++ b/src/scripts/Optimize-TaskScheduler.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ScheduledTaskState.psm1"
 
 # Adapted from: https://youtu.be/qWESrvP_uU8

--- a/src/scripts/Optimize-WindowsFeaturesList.ps1
+++ b/src/scripts/Optimize-WindowsFeaturesList.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-OptionalFeatureState.psm1"
 
 # Adapted from: https://github.com/ChrisTitusTech/win10script/pull/131/files

--- a/src/scripts/Register-PersonalTweaksList.ps1
+++ b/src/scripts/Register-PersonalTweaksList.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Open-File.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"

--- a/src/scripts/Remove-CapabilitiesList.ps1
+++ b/src/scripts/Remove-CapabilitiesList.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-CapabilityState.psm1"
 
 function Remove-CapabilitiesList() {

--- a/src/scripts/Remove-MSEdge.ps1
+++ b/src/scripts/Remove-MSEdge.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-UWPApp.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"

--- a/src/scripts/Remove-OneDrive.ps1
+++ b/src/scripts/Remove-OneDrive.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 
 function Remove-OneDrive() {

--- a/src/scripts/Remove-TemporaryFiles.ps1
+++ b/src/scripts/Remove-TemporaryFiles.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"
 
 function Remove-TemporaryFiles() {

--- a/src/scripts/Remove-WindowsOld.ps1
+++ b/src/scripts/Remove-WindowsOld.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\ui\Show-MessageDialog.psm1"
 
 function Remove-WindowsOld() {

--- a/src/scripts/Remove-Xbox.ps1
+++ b/src/scripts/Remove-Xbox.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-UWPApp.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ServiceStartup.psm1"

--- a/src/scripts/Repair-WindowsSystem.ps1
+++ b/src/scripts/Repair-WindowsSystem.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 
 # Adapted from: https://github.com/ChrisTitusTech/win10script

--- a/src/scripts/Start-DiskCleanUp.ps1
+++ b/src/scripts/Start-DiskCleanUp.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 
 function Start-DiskCleanUp() {
     [CmdletBinding()]

--- a/src/scripts/other-scripts/Git-GnupgSshKeysSetup.ps1
+++ b/src/scripts/other-scripts/Git-GnupgSshKeysSetup.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\debloat-helper\Remove-ItemVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\package-managers\Manage-Software.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\ui\Select-Folder.psm1"

--- a/src/scripts/other-scripts/Install-ArchWSL.ps1
+++ b/src/scripts/other-scripts/Install-ArchWSL.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Get-HardwareInfo.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Request-FileDownload.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\debloat-helper\Remove-ItemVerified.psm1"

--- a/src/scripts/other-scripts/Install-NerdFont.ps1
+++ b/src/scripts/other-scripts/Install-NerdFont.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Get-TempScriptFolder.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Get-TempScriptFolder.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Install-Font.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Request-FileDownload.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"

--- a/src/scripts/other-scripts/Install-WSL.ps1
+++ b/src/scripts/other-scripts/Install-WSL.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Get-HardwareInfo.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Request-FileDownload.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\debloat-helper\Remove-ItemVerified.psm1"

--- a/src/scripts/other-scripts/New-SystemColor.ps1
+++ b/src/scripts/other-scripts/New-SystemColor.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 
 function New-SystemColor() {

--- a/src/scripts/other-scripts/Show-DebloatInfo.ps1
+++ b/src/scripts/other-scripts/Show-DebloatInfo.ps1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\ui\Show-MessageDialog.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\ui\Show-MessageDialog.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\..\lib\ui\Ui-Helper.psm1" # Load UI libs
 
 function Show-DebloatInfo() {

--- a/src/utils/DIY/Optimize-SSD.ps1
+++ b/src/utils/DIY/Optimize-SSD.ps1
@@ -1,4 +1,4 @@
-function Optimize-SSD() {
+﻿function Optimize-SSD() {
     # SSD life improvement
     fsutil behavior set DisableLastAccess 1
     fsutil behavior set EncryptPagingFile 0

--- a/src/utils/DIY/Restart-AdvancedMode.ps1
+++ b/src/utils/DIY/Restart-AdvancedMode.ps1
@@ -1,4 +1,4 @@
-function Restart-AdvancedMode() {
+﻿function Restart-AdvancedMode() {
     # -r: Restart after shutdown
     # -o: Reboot into the advanced menu
     # -t: Time before shutdown

--- a/src/utils/Individual-Tweaks.psm1
+++ b/src/utils/Individual-Tweaks.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Get-HardwareInfo.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\New-Shortcut.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Remove-ItemVerified.psm1"

--- a/src/utils/Install-Individual-System-Apps.psm1
+++ b/src/utils/Install-Individual-System-Apps.psm1
@@ -1,4 +1,4 @@
-Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
+﻿Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\Title-Templates.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\debloat-helper\Set-ItemPropertyVerified.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\lib\package-managers\Manage-Software.psm1"
 Import-Module -DisableNameChecking "$PSScriptRoot\..\utils\Individual-Tweaks.psm1"


### PR DESCRIPTION
- May solve characters not displaying correctly for some languages. (needs testing)
- Fixes #174 (needs testing)